### PR TITLE
28216 ability to specify site

### DIFF
--- a/python/login.py
+++ b/python/login.py
@@ -33,6 +33,10 @@ class Login(object):
         login_manager = LoginImplementation.get_instance_for_namespace("My Application")
         login_info = login_manager.login(site="http://www.google.com")
 
+    It is possible to not specify a site, in that case latest login used with the
+    application will be used :
+        login_info = login_manager.login()
+
     If the login info has already been collected, it will be returned.  If the saved values
     successfully authenticate, then the resulting login info will be returned.  Otherwise a
     dialog is shown to the user to collect site/login/password.
@@ -293,7 +297,15 @@ class Login(object):
 
     # utilities ##############################################################################
     def _get_settings_group(self):
-        """ Return a Qsettings group name to store values in """
+        """
+        Return a Qsettings group name to store values in
+
+        If a site was specified in the login call, the name will have the following
+        form : loginInfo[/<protocol>]/<server name>[/<port number>], e.g.
+        sftp://my.server.com:22 will give 'loginInfo/sftp/my.server.com/22'
+
+        If no site was given, the name will be just 'loginInfo'
+        """
         group = "loginInfo"
         if self._site:
             parsed = urlparse(self._site)
@@ -344,6 +356,10 @@ class Login(object):
             raise ValueError("invalid site")
         if not login:
             raise ValueError("invalid login")
-
-        parse = urlparse(site)
+        # We use the full site url as our keyring name
+        # Another option would be parse it, and join parts with ".", if using
+        # "://" and ":" are causing problems.
+        # e.g. :
+        # parse = urlparse(site)
+        # keyring = ".".join([parse.scheme, parse.hostname, str(parse.port)])
         return ("%s.login" % site, login)

--- a/python/login.py
+++ b/python/login.py
@@ -126,9 +126,15 @@ class Login(object):
 
         self._site = site
 
+        if self._login_info and self._site != self._current_site:
+            # Attempt to login to a different site
+            # clear current login info
+            self._login_info = None
+            self._current_site = None
+
         if not force_dialog:
             # first check in memory cache
-            if self._login_info is not None and self._current_site == self._site:
+            if self._login_info is not None:
                 return self._login_info
 
             # next see if the saved values return a valid user
@@ -156,6 +162,7 @@ class Login(object):
             raise NotImplementedError("support for multiple sites is not yet implemented")
 
         self._login_info = None
+        self._current_site = None
         self._clear_password()
 
     ##########################################################################################

--- a/python/login.py
+++ b/python/login.py
@@ -31,7 +31,7 @@ class Login(object):
     To use the interface you should simply be able to request the login info from an
     implementation:
         login_manager = LoginImplementation.get_instance_for_namespace("My Application")
-        login_info = login_manager.login()
+        login_info = login_manager.login(site="http://www.google.com")
 
     If the login info has already been collected, it will be returned.  If the saved values
     successfully authenticate, then the resulting login info will be returned.  Otherwise a


### PR DESCRIPTION
Added the ability to specify a site when attempting to login, and changed the way values are stored so wrong credentials shouldn't be used anymore.
These changes do not cover the case where a user would log in to the same site using different accounts.